### PR TITLE
Update memo with new transaction links

### DIFF
--- a/mm/memo.md
+++ b/mm/memo.md
@@ -11,3 +11,9 @@ https://etherscan.io/tx/0xa1d6ed9d2833cc07a688eaeac82875b73c2da5cd50960b583d6117
 Input: 5K USDT
 
 https://etherscan.io/tx/0xb6907ceebf26eab9284e3cea3342c7e79e851a260ed1388f9694d011c9cc2a92
+
+7 Aug 2026:
+Remove CoW AMM liquidity:
+https://arbiscan.io/tx/0x9e94ebeabb8c0e9daddaffd415858a7684317129b874d080f9188ba718c45b4c
+Add UniswapV4 liquidity:
+https://arbiscan.io/tx/0xcd755de83e22cdee7bd0433bb1cec5a669458fbdfba1b11f7cdd2bcf32764937


### PR DESCRIPTION
Added transaction links for liquidity actions on 7 Aug 2026.